### PR TITLE
Do not populate User.Id when reading from okta

### DIFF
--- a/Depfile
+++ b/Depfile
@@ -2,13 +2,14 @@
 bin:
   vault:
     url: "https://releases.hashicorp.com/vault/{{.Version}}/vault_{{.Version}}_{{.OS}}_{{.Arch}}.zip"
-    version: "1.8.1"
+    version: "1.8.12"
     zipPaths:
     - "./vault"
     sha:
-      linux-amd64: "bb411f2bbad79c2e4f0640f1d3d5ef50e2bda7d4f40875a56917c95ff783c2db"
-      darwin-amd64: "f87221e4f56b3da41f0a029bf2b48896ec3be84dd7075bdb9466def1e056f809"
-      darwin-arm64: "571985c34990a2a7b913cee8c50be42b34c8d8cb751a2aed2c80121ad4b4e44b"
+      linux-amd64: "88c280945db62b118435ec1bf0086a719f6b6551cba052e5f8d1e25a80884bca"
+      linux-arm64: "e57e719e1eec9bce9057751e2583907210d3ac99c0a01897479506fbb2af828d"
+      darwin-amd64: "db30ea93bc9a87c37d0215515f4d28d3513f84b793c6f9958ac5dea6edd53242"
+      darwin-arm64: "18096cfdacba56a806f1b4b47ea20b3c03f062b5162c53a2b61b0b591d00aa65"
   oras:
     url: "https://github.com/oras-project/oras/releases/download/v{{.Version}}/oras_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz"
     version: "0.12.0"
@@ -19,7 +20,7 @@ bin:
       darwin-amd64:  "3637530cd3d01e2b3dc43fc4692edd36c71919726be9fdbb3b298ce0979bbabb"
       darwin-arm64:  "0cfb07da7c8d6ceef7a3850140c8d25bf64139b0cb3bf221fa4e7aeb0e0a1a73"
     tgzPaths:
-    - "./oras" 
+    - "./oras"
 
 go:
   sver:

--- a/pkg/srv/srv_test.go
+++ b/pkg/srv/srv_test.go
@@ -70,8 +70,13 @@ func TestReadUserByID(t *testing.T) {
 	users, err := p.Read()
 
 	assert.Nil(err)
-	assert.NotNil(users)
-	assert.Equal(users[0].Id, oktaUser.Id)
+	assert.Len(users, 1)
+
+	user := users[0]
+	assert.Empty(user.Id)
+
+	profile := *oktaUser.Profile
+	assert.Equal(user.Email, profile["login"].(string))
 }
 
 func TestReadUserByEmail(t *testing.T) {
@@ -87,8 +92,13 @@ func TestReadUserByEmail(t *testing.T) {
 	users, err := p.Read()
 
 	assert.Nil(err)
-	assert.NotNil(users)
-	assert.Equal(users[0].Id, oktaUser.Id)
+	assert.Len(users, 1)
+
+	user := users[0]
+	assert.Empty(user.Id)
+
+	profile := *oktaUser.Profile
+	assert.Equal(user.Email, profile["login"].(string))
 }
 
 func TestReadFailToRetriveUsers(t *testing.T) {
@@ -199,7 +209,7 @@ func TestReadMultiplePages(t *testing.T) {
 	assert.Nil(err)
 	assert.Len(users1, 2)
 	assert.Len(users2, 1)
-	assert.NotEqual(users1[0].Id, users2[0].Id)
+	assert.NotEqual(users1[0].DisplayName, users2[0].DisplayName)
 }
 
 func TestDeleteWithInvalidId(t *testing.T) {

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -83,7 +83,6 @@ func FromOkta(in *okta.User) *api.User {
 	}
 
 	user := api.User{
-		Id:          in.Id,
 		DisplayName: displayName,
 		Email:       email,
 		Picture:     "",

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -50,7 +50,7 @@ func TestFromOktaWithActiveCompleteUser(t *testing.T) {
 
 	apiUser := FromOkta(oktaUser)
 
-	assert.Equal("1", apiUser.Id, "should correctly detect the id")
+	assert.Empty(apiUser.Id, "should leave the id empty")
 	assert.Equal("First Last", apiUser.DisplayName, "should correctly construct the displayName")
 	assert.Equal("active", apiUser.Attributes.Properties.Fields["status"].GetStringValue(), "should add status to attributes")
 	assert.Equal("test", apiUser.Attributes.Properties.Fields["additional_info"].GetStringValue(), "should add additional profile info to attributes")
@@ -75,7 +75,7 @@ func TestFromOktaWithDeprovisionedUser(t *testing.T) {
 
 	apiUser := FromOkta(oktaUser)
 
-	assert.Equal("1", apiUser.Id, "should correctly detect the id")
+	assert.Empty(apiUser.Id, "should leave the id empty")
 	assert.Equal("deprovisioned", apiUser.Attributes.Properties.Fields["status"].GetStringValue(), "should add status to attributes")
 	assert.True(apiUser.Identities["1"].Verified, "should always add user id as verified")
 	assert.False(apiUser.Identities["testemail@test.com"].Verified, "should add user email as unverified")


### PR DESCRIPTION
The user ID is populated by the directory. The okta ID (PID) is an identity of the v1 user but not its ID.